### PR TITLE
fix: add upper limit to click for lamp posts

### DIFF
--- a/src/components/canvas/Canvas.js
+++ b/src/components/canvas/Canvas.js
@@ -240,8 +240,19 @@ class Canvas extends Component {
     return factor / height;
   };
 
+  isInBottomHalf = clientY => {
+    const { height } = this.state;
+    return clientY > height / 2;
+  };
+
   handleClick = ({ evt, target }) => {
-    const { clientX } = evt;
+    const { clientX, clientY } = evt;
+
+    // commands after this check only apply to the bottom half of the canvas
+    if (!this.isInBottomHalf(clientY)) {
+      return false;
+    }
+
     const { dispatchAddLampPost, lampPosts, lampPostActivity } = this.props;
 
     // do not consider clicks on the lamp posts


### PR DESCRIPTION
Only adding lamp posts if user clicks in the bottom
half of the screen.

closes #52