### PR TITLE
64/dim house halo

### DIFF
--- a/src/components/canvas/HouseHalo.js
+++ b/src/components/canvas/HouseHalo.js
@@ -18,9 +18,9 @@ const HouseHalo = ({ x, y }) => {
     .map((e, i) => {
       // emulating the law of inverse square,
       // but actually exponentiating to one
-      const color = `rgba(248, 148, 6, ${1 / (i + 1) ** 1})`;
+      const color = `rgba(248, 148, 6, ${1 / (i + 1) ** 1.4})`;
       const shadowBlur = 5;
-      const shadowOpacity = 0.1;
+      const shadowOpacity = 0.3;
 
       return (
         <Circle

--- a/src/components/canvas/Stars.js
+++ b/src/components/canvas/Stars.js
@@ -51,6 +51,18 @@ const generateStars = lampPosts => {
       r: 2.3,
     },
     {
+      x: 0.11 * width,
+      y: 0.55 * height,
+      opacity: 1 - calculateOpacity(numLampPosts),
+      r: 0.05,
+    },
+    {
+      x: 0.13 * width,
+      y: 0.54 * height,
+      opacity: 1 - calculateOpacity(numLampPosts),
+      r: 0.07,
+    },
+    {
       x: 0.13 * width,
       y: 0.29 * height,
       opacity: 1 - calculateOpacity(numLampPosts),


### PR DESCRIPTION
fix: dim house halo

- dimmed the halo of the house to make its intensity less strong than the one from the lamp posts
- added a couple of dim stars just above the roof of the house

close #64